### PR TITLE
Improve message list by displaying state of the message

### DIFF
--- a/RaceControlNotifier.xcodeproj/project.pbxproj
+++ b/RaceControlNotifier.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		DC1874C92A162786004530DA /* UserDefaultsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1874C82A162786004530DA /* UserDefaultsExtensions.swift */; };
 		DC1874CB2A163CED004530DA /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1874CA2A163CED004530DA /* DictionaryExtensions.swift */; };
+		DC1874CD2A1644AC004530DA /* MessageDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1874CC2A1644AC004530DA /* MessageDetailsView.swift */; };
 		DC47D8C3288C0FA200A32091 /* RaceControlNotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC47D8C2288C0FA200A32091 /* RaceControlNotifierApp.swift */; };
 		DC47D8C5288C0FA200A32091 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC47D8C4288C0FA200A32091 /* ContentView.swift */; };
 		DC47D8C7288C0FA500A32091 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC47D8C6288C0FA500A32091 /* Assets.xcassets */; };
@@ -46,6 +47,7 @@
 /* Begin PBXFileReference section */
 		DC1874C82A162786004530DA /* UserDefaultsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtensions.swift; sourceTree = "<group>"; };
 		DC1874CA2A163CED004530DA /* DictionaryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensions.swift; sourceTree = "<group>"; };
+		DC1874CC2A1644AC004530DA /* MessageDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailsView.swift; sourceTree = "<group>"; };
 		DC47D8BF288C0FA200A32091 /* RaceControlNotifier.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RaceControlNotifier.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC47D8C2288C0FA200A32091 /* RaceControlNotifierApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceControlNotifierApp.swift; sourceTree = "<group>"; };
 		DC47D8C4288C0FA200A32091 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			children = (
 				DCA1DCA3290DC9EF002A1AB1 /* MessageListView.swift */,
 				DCA1DCA5290DCA85002A1AB1 /* MessageListItemView.swift */,
+				DC1874CC2A1644AC004530DA /* MessageDetailsView.swift */,
 			);
 			path = MessageList;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 				DC5502F528F1B4690024113C /* SettingsView.swift in Sources */,
 				DC47D8D6288C132B00A32091 /* RCMNotifier.swift in Sources */,
 				DC1874C92A162786004530DA /* UserDefaultsExtensions.swift in Sources */,
+				DC1874CD2A1644AC004530DA /* MessageDetailsView.swift in Sources */,
 				DC47D8D8288C288E00A32091 /* TextToSpeech.swift in Sources */,
 				DC47D8C5288C0FA200A32091 /* ContentView.swift in Sources */,
 				DC6ABF0E28F2AA9A008E7702 /* FlagToggleView.swift in Sources */,

--- a/RaceControlNotifier.xcodeproj/project.pbxproj
+++ b/RaceControlNotifier.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		DC1874C92A162786004530DA /* UserDefaultsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1874C82A162786004530DA /* UserDefaultsExtensions.swift */; };
+		DC1874CB2A163CED004530DA /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1874CA2A163CED004530DA /* DictionaryExtensions.swift */; };
 		DC47D8C3288C0FA200A32091 /* RaceControlNotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC47D8C2288C0FA200A32091 /* RaceControlNotifierApp.swift */; };
 		DC47D8C5288C0FA200A32091 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC47D8C4288C0FA200A32091 /* ContentView.swift */; };
 		DC47D8C7288C0FA500A32091 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC47D8C6288C0FA500A32091 /* Assets.xcassets */; };
@@ -44,6 +45,7 @@
 
 /* Begin PBXFileReference section */
 		DC1874C82A162786004530DA /* UserDefaultsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtensions.swift; sourceTree = "<group>"; };
+		DC1874CA2A163CED004530DA /* DictionaryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensions.swift; sourceTree = "<group>"; };
 		DC47D8BF288C0FA200A32091 /* RaceControlNotifier.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RaceControlNotifier.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC47D8C2288C0FA200A32091 /* RaceControlNotifierApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceControlNotifierApp.swift; sourceTree = "<group>"; };
 		DC47D8C4288C0FA200A32091 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				DC47D8D7288C288E00A32091 /* TextToSpeech.swift */,
 				DC5502F628F1C5520024113C /* RaceControlMessageCategory.swift */,
 				DC5502F828F1C58E0024113C /* FlagColor.swift */,
+				DC1874CA2A163CED004530DA /* DictionaryExtensions.swift */,
 			);
 			path = RaceControlNotifier;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 				DC55032C28F20C660024113C /* FlagPreviewButtonView.swift in Sources */,
 				DC47D8D2288C0FC700A32091 /* RCMFetcher.swift in Sources */,
 				DCA1DCA6290DCA85002A1AB1 /* MessageListItemView.swift in Sources */,
+				DC1874CB2A163CED004530DA /* DictionaryExtensions.swift in Sources */,
 				DC5502F928F1C58E0024113C /* FlagColor.swift in Sources */,
 				DCA1DCA4290DC9EF002A1AB1 /* MessageListView.swift in Sources */,
 				DC47D8D4288C114B00A32091 /* RaceControlMessageModel.swift in Sources */,

--- a/RaceControlNotifier.xcodeproj/xcuserdata/Felix.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/RaceControlNotifier.xcodeproj/xcuserdata/Felix.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -14,10 +14,10 @@
             filePath = "RaceControlNotifier/RCMNotifier.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "83"
-            endingLineNumber = "83"
+            startingLineNumber = "102"
+            endingLineNumber = "102"
             landmarkName = "fetchNewMessages()"
-            landmarkType = "9">
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -46,9 +46,41 @@
             filePath = "RaceControlNotifier/TextToSpeech.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "118"
-            endingLineNumber = "118"
-            landmarkName = "say(_:)"
+            startingLineNumber = "134"
+            endingLineNumber = "134"
+            landmarkName = "sayInternal(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "BEF7E801-210E-4C16-94FE-175AFD9CF56A"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RaceControlNotifier/RCMNotifier.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "47"
+            endingLineNumber = "47"
+            landmarkName = "startObservingSettings()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "766189A2-7153-494E-BB62-93494162D667"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RaceControlNotifier/TextToSpeech.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "176"
+            endingLineNumber = "176"
+            landmarkName = "speechSynthesizer(_:didFinish:)"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/RaceControlNotifier/DictionaryExtensions.swift
+++ b/RaceControlNotifier/DictionaryExtensions.swift
@@ -1,0 +1,28 @@
+//
+// RaceControlNotifier for MultiViewer
+// Copyright (c) 2023  FelixSFD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+
+/// Extensions for the dictionary
+extension Dictionary where Value: Equatable {
+    /// Finds the key for a value
+    /// Source: https://stackoverflow.com/a/41386238/4687348
+    func getFirstKeyForValue(forValue val: Value) -> Key? {
+        return first(where: { $1 == val })?.key
+    }
+}

--- a/RaceControlNotifier/MessageList/MessageDetailsView.swift
+++ b/RaceControlNotifier/MessageList/MessageDetailsView.swift
@@ -1,0 +1,62 @@
+//
+// RaceControlNotifier for MultiViewer
+// Copyright (c) 2023  FelixSFD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct MessageDetailsView: View {
+    @State
+    var message: RaceControlMessageModel
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(message.message)
+                .fontWeight(.bold)
+            
+            VStack {
+                HStack {
+                    Text("Category:")
+                    Spacer()
+                    Text(message.category.rawValue)
+                }
+                
+                HStack {
+                    Text("Date:")
+                    Spacer()
+                    Text(message.date.ISO8601Format(.iso8601))
+                }
+                
+                if message.category == .flag && message.flag != nil {
+                    HStack {
+                        Text("Flag color:")
+                        Spacer()
+                        Text(String(reflecting: message.flag!))
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct MessageDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        MessageDetailsView(message: RaceControlMessageModel(date: Date.now, message: "TEST MESSAGE - SAFETY CAR DEPLOYED", category: .other, ttsEnabled: true))
+        
+        MessageDetailsView(message: RaceControlMessageModel(date: Date.now, message: "TEST MESSAGE - RED FLAG", category: .flag, flag: .red, ttsEnabled: true))
+        
+        MessageDetailsView(message: RaceControlMessageModel(date: Date.now, message: "TEST MESSAGE - BLUE FLAG FOR MAZESPIN", category: .flag, flag: .blue, ttsEnabled: false))
+    }
+}

--- a/RaceControlNotifier/MessageList/MessageListItemView.swift
+++ b/RaceControlNotifier/MessageList/MessageListItemView.swift
@@ -24,19 +24,37 @@ struct MessageListItemView: View {
     @State
     var date: Date
     
+    
+    @State
+    var ttsEnabled: Bool
+    
     var body: some View {
         VStack(alignment: .leading) {
             Text(messageText)
                 .fontWeight(.bold)
-            Text(date.formatted())
-                .font(.caption2.italic())
-                .foregroundColor(.gray)
+            
+            HStack(alignment: .center) {
+                Text(date.formatted())
+                    .font(.caption2.italic())
+                    .foregroundColor(.gray)
+                
+                Spacer()
+                
+                if ttsEnabled {
+                    Image(systemName: "speaker.wave.2.circle")
+                } else {
+                    Image(systemName: "speaker.slash.circle")
+                }
+            }
         }
+        .opacity(ttsEnabled ? 1 : 0.7)
     }
 }
 
 struct MessageListItemView_Previews: PreviewProvider {
     static var previews: some View {
-        MessageListItemView(messageText: "TEST MESSAGE - RED FLAG", date: Date.now)
+        MessageListItemView(messageText: "TEST MESSAGE - RED FLAG", date: Date.now, ttsEnabled: true)
+        
+        MessageListItemView(messageText: "TEST MESSAGE - BLUE FLAG - NO TTS", date: Date.now, ttsEnabled: false)
     }
 }

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -33,6 +33,10 @@ struct MessageListView: View {
     private var isSpeaking: Bool = false
     
     
+    @State
+    private var showingMessageDetail: RaceControlMessageModel? = nil
+    
+    
     var body: some View {
         List {
             ForEach($rcmNotifier.reversedMessages) { message in
@@ -49,10 +53,27 @@ struct MessageListView: View {
                     
                     MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue, ttsEnabled: message.ttsEnabled.wrappedValue)
                         .listRowSeparatorTint(.gray)
+                        .contextMenu {
+                            Button("Details") {
+                                print("Should display sheet now")
+                                showingMessageDetail = message.wrappedValue
+                            }
+                        }
                 }
             }
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
+        .sheet(item: $showingMessageDetail) {
+            msgItem in
+            VStack {
+                MessageDetailsView(message: msgItem)
+                Button("Close") {
+                    showingMessageDetail = nil
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        }
     }
 }
 

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -45,6 +45,7 @@ struct MessageListView: View {
                         Image(systemName: symbolName)
                             .frame(width: 15)
                     }
+                    .disabled(tts.currentlySpeaking[message.id] != nil)
                     
                     MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue, ttsEnabled: message.ttsEnabled.wrappedValue)
                         .listRowSeparatorTint(.gray)

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -25,7 +25,12 @@ struct MessageListView: View {
     private var messages: [RaceControlMessageModel] = []
     
     
-    let tts: TextToSpeech
+    @ObservedObject
+    var tts: TextToSpeech
+    
+    
+    @State
+    private var isSpeaking: Bool = false
     
     
     var body: some View {
@@ -33,9 +38,13 @@ struct MessageListView: View {
             ForEach($rcmNotifier.reversedMessages) { message in
                 HStack {
                     Button {
-                        tts.say(message.message.wrappedValue)
+                        tts.say(message.message.wrappedValue, messageId: message.id)
                     } label: {
-                        Image(systemName: "play")
+                        if (tts.currentlySpeaking[message.id] == nil) {
+                            Image(systemName: "play")
+                        } else {
+                            Image(systemName: "stop.fill")
+                        }
                     }
                     
                     MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue, ttsEnabled: message.ttsEnabled.wrappedValue)

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -43,7 +43,7 @@ struct MessageListView: View {
                 }
             }
         }
-        .listStyle(.bordered)
+        .listStyle(.inset(alternatesRowBackgrounds: true))
     }
 }
 

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -38,7 +38,7 @@ struct MessageListView: View {
                         Image(systemName: "play")
                     }
                     
-                    MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue)
+                    MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue, ttsEnabled: message.ttsEnabled.wrappedValue)
                         .listRowSeparatorTint(.gray)
                 }
             }
@@ -48,7 +48,7 @@ struct MessageListView: View {
 }
 
 struct MessageListView_Previews: PreviewProvider {
-    @State static var sampleMessages = [RaceControlMessageModel(date: Date.now, message: "CAR 63 (RUS) TIME 1:19.376 DELETED - TRACK LIMITS AT TURN 12 LAP 18 15:59:37", category: .other), RaceControlMessageModel(date: Date.now, message: "CHEQUERED FLAG", category: .flag)]
+    @State static var sampleMessages = [RaceControlMessageModel(date: Date.now, message: "CAR 63 (RUS) TIME 1:19.376 DELETED - TRACK LIMITS AT TURN 12 LAP 18 15:59:37", category: .other, ttsEnabled: true), RaceControlMessageModel(date: Date.now, message: "CHEQUERED FLAG", category: .flag, ttsEnabled: false)]
     
     private static var notifier = RCMNotifier(fetcher: RCMFetcher(), textToSpeech: TextToSpeech())
     

--- a/RaceControlNotifier/MessageList/MessageListView.swift
+++ b/RaceControlNotifier/MessageList/MessageListView.swift
@@ -40,11 +40,10 @@ struct MessageListView: View {
                     Button {
                         tts.say(message.message.wrappedValue, messageId: message.id)
                     } label: {
-                        if (tts.currentlySpeaking[message.id] == nil) {
-                            Image(systemName: "play")
-                        } else {
-                            Image(systemName: "stop.fill")
-                        }
+                        let symbolName = tts.currentlySpeaking[message.id] == nil ? "play" : "stop.fill"
+                        
+                        Image(systemName: symbolName)
+                            .frame(width: 15)
                     }
                     
                     MessageListItemView(messageText: message.message.wrappedValue, date: message.date.wrappedValue, ttsEnabled: message.ttsEnabled.wrappedValue)

--- a/RaceControlNotifier/RCMNotifier.swift
+++ b/RaceControlNotifier/RCMNotifier.swift
@@ -75,16 +75,18 @@ class RCMNotifier: ObservableObject {
         do {
             let allMessages = try await fetcher.getMessages()
             allMessages.forEach {
-                newMessage in
+                newMessage1 in
+                var newMessage = newMessage1
                 let announceEnabled = messageAnnouncementEnabled(newMessage)
+                newMessage.ttsEnabled = announceEnabled
                 
-                if newMessage.date > latestMessageDate && announceEnabled {
+                if newMessage.date > latestMessageDate {
                     self.messages.append(newMessage)
                     newlyAddedMessages.insert(newMessage, at: 0)
                     print("Added: \(newMessage.message)")
                     print(newMessage.date)
                     
-                    if speakMessages {
+                    if speakMessages && announceEnabled {
                         tts.say(newMessage.message)
                     }
                 }

--- a/RaceControlNotifier/RCMNotifier.swift
+++ b/RaceControlNotifier/RCMNotifier.swift
@@ -87,7 +87,7 @@ class RCMNotifier: ObservableObject {
                     print(newMessage.date)
                     
                     if speakMessages && announceEnabled {
-                        tts.say(newMessage.message)
+                        tts.say(newMessage.message, messageId: newMessage.id)
                     }
                 }
             }

--- a/RaceControlNotifier/RaceControlMessageModel.swift
+++ b/RaceControlNotifier/RaceControlMessageModel.swift
@@ -25,4 +25,7 @@ struct RaceControlMessageModel: Identifiable {
     var message: String
     var category: RaceControlMessageCategory
     var flag: FlagColor?
+    
+    /// true, if text-to-speech is enabled for this message
+    var ttsEnabled: Bool = false
 }


### PR DESCRIPTION
Messages that are filtered by the user's rules are now displayed with an icon indicating that they won't be read aloud.
Additionally, we can now see which messages are currently being read aloud (or are in the queue)